### PR TITLE
Per paper, make potentials signed (instead of {0,1}) and IMPLY natural

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -70,8 +70,8 @@ typedef variable_value_t variable_value_index_t;  // an alias to disambiguate
 
 // enumeration for factor function types
 typedef enum FACTOR_FUNCTION_TYPE {
-  FUNC_IMPLY_MLN = 0,
-  FUNC_IMPLY_neg1_1 = 11,
+  FUNC_IMPLY_MLN = 13,
+  FUNC_IMPLY_NATURAL = 0,
   FUNC_OR = 1,
   FUNC_AND = 2,
   FUNC_EQUAL = 3,

--- a/src/factor.h
+++ b/src/factor.h
@@ -72,7 +72,7 @@ class CompactFactor {
     RETURN_POTENTIAL_FOR(func_id)
     switch (func_id) {
       RETURN_POTENTIAL_FOR(FUNC_IMPLY_MLN);
-      RETURN_POTENTIAL_FOR(FUNC_IMPLY_neg1_1);
+      RETURN_POTENTIAL_FOR(FUNC_IMPLY_NATURAL);
       RETURN_POTENTIAL_FOR2(FUNC_AND, FUNC_ISTRUE);
       RETURN_POTENTIAL_FOR(FUNC_OR);
       RETURN_POTENTIAL_FOR(FUNC_EQUAL);
@@ -125,9 +125,9 @@ class CompactFactor {
       const bool satisfied =
           is_variable_satisfied(vif, vid, var_values, proposal);
       /* Early return as soon as we find a mismatch */
-      if (satisfied != firstsat) return 0.0;
+      if (satisfied != firstsat) return -1;
     }
-    return 1.0;
+    return 1;
   }
 
   /** Return the value of the logical AND of the variables in the factor, with
@@ -143,9 +143,9 @@ class CompactFactor {
       const bool satisfied =
           is_variable_satisfied(vif, vid, var_values, proposal);
       /* Early return as soon as we find a variable that is not satisfied */
-      if (!satisfied) return 0.0;
+      if (!satisfied) return -1;
     }
-    return 1.0;
+    return 1;
   }
 
   /** Return the value of the logical OR of the variables in the factor, with
@@ -161,9 +161,9 @@ class CompactFactor {
       const bool satisfied =
           is_variable_satisfied(vif, vid, var_values, proposal);
       /* Early return as soon as we find a variable that is satisfied */
-      if (satisfied) return 1.0;
+      if (satisfied) return 1;
     }
-    return 0.0;
+    return -1;
   }
 
   /** Return the value of the 'imply (MLN version)' of the variables in the
@@ -190,14 +190,14 @@ class CompactFactor {
 
     if (!bBody) {
       // Early return if the body is not satisfied
-      return 1.0;
+      return 1;
     } else {
       // Compute the value of the head of the rule
       const VariableInFactor &vif = vifs[n_start_i_vif + n_variables -
                                          1];  // encoding of the head, should
                                               // be more structured.
       const bool bHead = is_variable_satisfied(vif, vid, var_values, proposal);
-      return bHead ? 1.0 : 0.0;
+      return bHead ? 1 : 0;
     }
   }
 
@@ -213,7 +213,7 @@ class CompactFactor {
    *  return 0.0 if the body is not satisfied.
    *
    */
-  DEFINE_POTENTIAL_FOR(FUNC_IMPLY_neg1_1) {
+  DEFINE_POTENTIAL_FOR(FUNC_IMPLY_NATURAL) {
     /* Compute the value of the body of the rule */
     bool bBody = true;
     for (num_edges_t i_vif = n_start_i_vif;
@@ -225,14 +225,14 @@ class CompactFactor {
 
     if (!bBody) {
       // Early return if the body is not satisfied
-      return 0.0;
+      return 0;
     } else {
       // Compute the value of the head of the rule */
       const VariableInFactor &vif = vifs[n_start_i_vif + n_variables -
                                          1];  // encoding of the head, should
                                               // be more structured.
       bool bHead = is_variable_satisfied(vif, vid, var_values, proposal);
-      return bHead ? 1.0 : -1.0;
+      return bHead ? 1 : -1;
     }
   }
 

--- a/test/biased_coin/check_result
+++ b/test/biased_coin/check_result
@@ -8,18 +8,18 @@ set -eu
 
 # check results
 
-# all weights should be around 2.1
+# all weights should be around 1.0
 awk <inference_result.out.weights.text '{
     id=$1; weight=$2;
-    expected=2.1
+    expected=1.0
     eps=0.1
     if ((weight > expected + eps) || (weight < expected - eps)) {
-        print "weight " id " not around " 2.1
+        print "weight " id " not around " 1.0
         exit(1)
     }
 }'
 
-# all probabilities should be around 0.89
+# all probabilities should be around 0.89 (e ^ w / (e ^ w + e ^ -w))
 awk <inference_result.out.text '{
     id=$1; e=$2; prob=$3;
     expected=0.89

--- a/test/factor_graph_test.cc
+++ b/test/factor_graph_test.cc
@@ -54,13 +54,13 @@ TEST_F(FactorGraphTest, update_weight) {
 
   cfg->update_weight(cfg->variables[0], *infrs, 0.1);
   std::cout << "The weight value is: " << infrs->weight_values[0] << std::endl;
-  EXPECT_EQ(infrs->weight_values[0], 0.1);
+  EXPECT_EQ(infrs->weight_values[0], 0.2);
 
   cfg->update_weight(cfg->variables[10], *infrs, 0.1);
-  EXPECT_EQ(infrs->weight_values[0], 0.1);
+  EXPECT_EQ(infrs->weight_values[0], 0.2);
 
   cfg->update_weight(cfg->variables[10], *infrs, 0.1);
-  EXPECT_EQ(infrs->weight_values[0], 0.1);
+  EXPECT_EQ(infrs->weight_values[0], 0.2);
 }
 
 }  // namespace dd

--- a/test/factor_test.cc
+++ b/test/factor_test.cc
@@ -29,7 +29,7 @@ TEST(FactorTest, ONE_VAR_FACTORS) {
   EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), 1.0, EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_OR)(vifs, values, vid, propose), 1.0, EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_EQUAL)(vifs, values, vid, propose), 1.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), 1.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_LINEAR)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
@@ -39,10 +39,10 @@ TEST(FactorTest, ONE_VAR_FACTORS) {
 
   // CASE 2: False
   propose = 0;
-  EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), 0.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_OR)(vifs, values, vid, propose), 0.0, EQ_TOL);
+  EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), -1, EQ_TOL);
+  EXPECT_NEAR(f.POTENTIAL(FUNC_OR)(vifs, values, vid, propose), -1, EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_EQUAL)(vifs, values, vid, propose), 1.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), -1.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), -1.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_LINEAR)(vifs, values, vid, propose), 0.0,
               EQ_TOL);
@@ -75,7 +75,7 @@ TEST(FactorTest, TWO_VAR_FACTORS) {
   EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), 1.0, EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_OR)(vifs, values, vid, propose), 1.0, EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_EQUAL)(vifs, values, vid, propose), 1.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), 1.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_LINEAR)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
@@ -88,10 +88,10 @@ TEST(FactorTest, TWO_VAR_FACTORS) {
   values[1] = 1;
   vid = 1;
   propose = 0;
-  EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), 0.0, EQ_TOL);
+  EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), -1, EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_OR)(vifs, values, vid, propose), 1.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_EQUAL)(vifs, values, vid, propose), 0.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), -1.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_EQUAL)(vifs, values, vid, propose), -1, EQ_TOL);
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), -1.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_LINEAR)(vifs, values, vid, propose), 0.0,
               EQ_TOL);
@@ -104,10 +104,10 @@ TEST(FactorTest, TWO_VAR_FACTORS) {
   values[1] = 0;
   vid = 1;
   propose = 1;
-  EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), 0.0, EQ_TOL);
+  EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), -1, EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_OR)(vifs, values, vid, propose), 1.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_EQUAL)(vifs, values, vid, propose), 0.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), 0.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_EQUAL)(vifs, values, vid, propose), -1, EQ_TOL);
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), 0.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_LINEAR)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
@@ -120,10 +120,10 @@ TEST(FactorTest, TWO_VAR_FACTORS) {
   values[1] = 0;
   vid = 1;
   propose = 0;
-  EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), 0.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_OR)(vifs, values, vid, propose), 0.0, EQ_TOL);
+  EXPECT_NEAR(f.POTENTIAL(FUNC_AND)(vifs, values, vid, propose), -1, EQ_TOL);
+  EXPECT_NEAR(f.POTENTIAL(FUNC_OR)(vifs, values, vid, propose), -1, EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_EQUAL)(vifs, values, vid, propose), 1.0, EQ_TOL);
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), 0.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), 0.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_LINEAR)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
@@ -159,7 +159,7 @@ TEST(FactorTest, THREE_VAR_IMPLY) {
   f.n_variables = 3;
   f.n_start_i_vif = 0;
 
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), 0.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), 0.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_MLN)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
@@ -172,7 +172,7 @@ TEST(FactorTest, THREE_VAR_IMPLY) {
 
   // second test case: True /\ x => True, x propose to True, Expect 1
   propose = 1;
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), 1.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_MLN)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
@@ -186,7 +186,7 @@ TEST(FactorTest, THREE_VAR_IMPLY) {
   // third test case: True /\ True => x, x propose to False, Expect -1
   vid = 2;
   propose = 0;
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), -1.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), -1.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_MLN)(vifs, values, vid, propose), 0.0,
               EQ_TOL);
@@ -199,7 +199,7 @@ TEST(FactorTest, THREE_VAR_IMPLY) {
   // forth test case: True /\ True => x, x propose to True, Expect 1
   vid = 2;
   propose = 1;
-  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_neg1_1)(vifs, values, vid, propose), 1.0,
+  EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_NATURAL)(vifs, values, vid, propose), 1.0,
               EQ_TOL);
   EXPECT_NEAR(f.POTENTIAL(FUNC_IMPLY_MLN)(vifs, values, vid, propose), 1.0,
               EQ_TOL);

--- a/test/sampler_test.cc
+++ b/test/sampler_test.cc
@@ -53,13 +53,13 @@ TEST_F(SamplerTest, sample_sgd_single_variable) {
   sampler->set_random_seed(1, 1, 1);
 
   sampler->sample_sgd_single_variable(0, 0.1);
-  EXPECT_EQ(infrs->weight_values[0], 0.1);
+  EXPECT_EQ(infrs->weight_values[0], 0.2);
 
   sampler->sample_sgd_single_variable(0, 0.1);
-  EXPECT_EQ(infrs->weight_values[0], 0.1);
+  EXPECT_EQ(infrs->weight_values[0], 0.2);
 
   sampler->sample_sgd_single_variable(0, 0.1);
-  EXPECT_EQ(infrs->weight_values[0], 0.1);
+  EXPECT_EQ(infrs->weight_values[0], 0.2);
 }
 
 // test for sample_single_variable


### PR DESCRIPTION
See section 2.4 of http://i.stanford.edu/hazy/papers/inc.pdf

I didn't touch `FUNC_LINEAR`, `FUNC_RATIO`, and `FUNC_LOGICAL` because they seem to be experiment code and the grounding setup seems different from the typical representation.

Related to https://github.com/HazyResearch/sampler/issues/26