### PR TITLE
Fixes the broken `-c`/`--n_datacopy` option 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ SOURCES += src/factor_graph.cc
 SOURCES += src/inference_result.cc
 SOURCES += src/gibbs_sampler.cc
 SOURCES += src/timer.cc
+SOURCES += src/numa_nodes.cc
 OBJECTS = $(SOURCES:.cc=.o)
 PROGRAM = dw
 

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <vector>
+#include <ostream>
 
 namespace dd {
 
@@ -12,6 +13,14 @@ namespace dd {
  * Command line argument parser
  */
 class CmdParser {
+ private:
+  size_t num_errors_;
+
+  /**
+   * A handy way to check conditions, record errors, and produce error messages.
+   */
+  std::ostream &check(bool condition);
+
  public:
   // all the arguments are defined in cmd_parser.cpp
   std::string app_name;
@@ -45,6 +54,8 @@ class CmdParser {
   factor_function_type_t text2bin_factor_func_id;
   factor_arity_t text2bin_factor_arity;
   std::vector<variable_value_t> text2bin_factor_variables_should_equal_to;
+
+  size_t num_errors() { return num_errors_; }
 
   /**
    * Constructs by parsing the given command line arguments

--- a/src/common.h
+++ b/src/common.h
@@ -5,29 +5,6 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#ifndef __MACH__
-#include <numa.h>
-#include <numaif.h>
-#endif
-
-// The author knows that this is really ugly...
-// But what can we do? Lets hope our Macbook
-// supporting NUMA soon! A 2lbs laptop with
-// 4 NUMA nodes, how cool is that!
-#ifdef __MACH__
-#include <math.h>
-#include <stdlib.h>
-
-#define numa_alloc_onnode(X, Y) malloc(X)
-
-#define numa_max_node() 0
-
-#define numa_run_on_node(X) 0
-
-#define numa_set_localalloc() 0
-
-#endif
-
 #include <math.h>
 
 #define LOG_2 0.693147180559945

--- a/src/dimmwitted.h
+++ b/src/dimmwitted.h
@@ -25,18 +25,14 @@ int gibbs(const CmdParser& cmd_parser);
  * Note the factor graph is copied on each NUMA node.
  */
 class DimmWitted {
+ private:
+  const size_t n_samplers_;
+
  public:
   const Weight* const weights;  // TODO clarify ownership
 
   // command line parser
   const CmdParser& opts;  // TODO clarify ownership
-
-  // the highest node number available
-  // actually, number of NUMA nodes = n_numa_nodes + 1
-  size_t n_numa_nodes;
-
-  // number of threads per NUMA node
-  size_t n_thread_per_numa;
 
   // factor graph copies per NUMA node
   std::vector<GibbsSampler> samplers;

--- a/src/gibbs_sampler.h
+++ b/src/gibbs_sampler.h
@@ -3,6 +3,7 @@
 
 #include "common.h"
 #include "factor_graph.h"
+#include "numa_nodes.h"
 #include "timer.h"
 #include <stdlib.h>
 #include <thread>
@@ -18,6 +19,7 @@ class GibbsSampler {
  private:
   std::unique_ptr<CompactFactorGraph> pfg;
   std::unique_ptr<InferenceResult> pinfrs;
+  NumaNodes numa_nodes_;
   std::vector<GibbsSamplerThread> workers;
   std::vector<std::thread> threads;
 
@@ -35,7 +37,8 @@ class GibbsSampler {
    * node id.
    */
   GibbsSampler(std::unique_ptr<CompactFactorGraph> pfg, const Weight weights[],
-               size_t nthread, size_t nodeid, const CmdParser &opts);
+               const NumaNodes &numa_nodes, size_t nthread, size_t nodeid,
+               const CmdParser &opts);
 
   /**
    * Performs sample

--- a/src/inference_result.cc
+++ b/src/inference_result.cc
@@ -1,6 +1,7 @@
 #include "inference_result.h"
 #include "factor_graph.h"
 #include <iostream>
+#include <memory>
 
 namespace dd {
 
@@ -46,23 +47,16 @@ InferenceResult::InferenceResult(const CompactFactorGraph &fg,
 
 InferenceResult::InferenceResult(const InferenceResult &other)
     : InferenceResult(other.fg, other.opts) {
-  memcpy(assignments_evid.get(), other.assignments_evid.get(),
-         sizeof(*assignments_evid.get()) * nvars);
-  memcpy(agg_means.get(), other.agg_means.get(),
-         sizeof(*agg_means.get()) * nvars);
-  memcpy(agg_nsamples.get(), other.agg_nsamples.get(),
-         sizeof(*agg_nsamples.get()) * nvars);
+  COPY_ARRAY_UNIQUE_PTR_MEMBER(assignments_evid, nvars);
+  COPY_ARRAY_UNIQUE_PTR_MEMBER(agg_means, nvars);
+  COPY_ARRAY_UNIQUE_PTR_MEMBER(agg_nsamples, nvars);
 
-  memcpy(weight_values.get(), other.weight_values.get(),
-         sizeof(*weight_values.get()) * nweights);
-  memcpy(weights_isfixed.get(), other.weights_isfixed.get(),
-         sizeof(*weights_isfixed.get()) * nweights);
+  COPY_ARRAY_UNIQUE_PTR_MEMBER(weight_values, nweights);
+  COPY_ARRAY_UNIQUE_PTR_MEMBER(weights_isfixed, nweights);
 
   ntallies = other.ntallies;
   categorical_tallies.reset(new num_samples_t[ntallies]);
-  for (num_tallies_t i = 0; i < ntallies; ++i) {
-    categorical_tallies[i] = other.categorical_tallies[i];
-  }
+  COPY_ARRAY_UNIQUE_PTR_MEMBER(categorical_tallies, ntallies);
 }
 
 void InferenceResult::merge_weights_from(const InferenceResult &other) {

--- a/src/numa_nodes.cc
+++ b/src/numa_nodes.cc
@@ -1,0 +1,77 @@
+#include "numa_nodes.h"
+
+#include <sstream>
+#include <cassert>
+
+#ifdef __linux__
+
+// libnuma on Linux
+#include <numa.h>
+#include <numaif.h>
+
+#else  // __linux__
+
+// portability shims for platforms without libnuma support, e.g., Mac
+#define numa_num_configured_nodes() 1
+#define numa_bind(bmp)
+#define numa_parse_nodestring(str) nullptr
+#define numa_bitmask_alloc(n) nullptr
+#define numa_bitmask_free(bmp)
+
+#endif  // __linux__
+
+namespace dd {
+
+NumaNodes::NumaNodes(const std::string& nodestring)
+    : nodestring_(nodestring), numa_nodemask_(nullptr) {}
+
+NumaNodes::~NumaNodes() {
+  if (numa_nodemask_) numa_bitmask_free(numa_nodemask_);
+}
+
+NumaNodes::NumaNodes(const NumaNodes& other) : NumaNodes(other.nodestring_) {}
+NumaNodes& NumaNodes::operator=(NumaNodes other) {
+  swap(other);
+  return *this;
+}
+void NumaNodes::swap(NumaNodes& other) {
+  std::swap(nodestring_, other.nodestring_);
+  std::swap(numa_nodemask_, other.numa_nodemask_);
+}
+
+struct bitmask* NumaNodes::numa_nodemask() {
+  if (!numa_nodemask_)
+    numa_nodemask_ = numa_parse_nodestring(nodestring_.c_str());
+  return numa_nodemask_;
+}
+void NumaNodes::bind() { numa_bind(numa_nodemask()); }
+void NumaNodes::unbind() { numa_bind(numa_nodemask()); }
+
+size_t NumaNodes::num_configured() { return numa_num_configured_nodes(); }
+
+NumaNodes NumaNodes::partition(size_t ith_part, size_t num_parts) {
+  size_t num_numa_nodes = num_configured();
+  assert(num_numa_nodes % num_parts == 0);
+
+  size_t num_numa_nodes_per_part = num_numa_nodes / num_parts;
+  size_t begin = ith_part * num_numa_nodes_per_part;
+  size_t end = begin + num_numa_nodes_per_part - 1;
+
+  std::ostringstream nodestringstream;
+  nodestringstream << begin << "-" << end;
+  return NumaNodes(nodestringstream.str());
+}
+
+std::vector<NumaNodes> NumaNodes::partition(size_t num_parts) {
+  std::vector<NumaNodes> parts;
+  for (size_t i = 0; i < num_parts; ++i) {
+    parts.push_back(partition(i, num_parts));
+  }
+  return parts;
+}
+
+std::ostream& operator<<(std::ostream& output, const NumaNodes& numa_nodes) {
+  return output << numa_nodes.nodestring_;
+}
+
+}  // namespace dd

--- a/src/numa_nodes.cc
+++ b/src/numa_nodes.cc
@@ -40,8 +40,7 @@ void NumaNodes::swap(NumaNodes& other) {
 }
 
 struct bitmask* NumaNodes::numa_nodemask() {
-  if (!numa_nodemask_)
-    numa_nodemask_ = numa_parse_nodestring(nodestring_.c_str());
+  if (!numa_nodemask_) numa_nodemask_ = numa_parse_nodestring(&nodestring_[0]);
   return numa_nodemask_;
 }
 void NumaNodes::bind() { numa_bind(numa_nodemask()); }

--- a/src/numa_nodes.h
+++ b/src/numa_nodes.h
@@ -1,0 +1,75 @@
+#ifndef DIMMWITTED_NUMA_NODES_H_
+#define DIMMWITTED_NUMA_NODES_H_
+
+#include <string>
+#include <vector>
+#include <ostream>
+
+struct bitmask;  // just need a forward declaration since we only point to it
+
+namespace dd {
+
+/**
+ * A class for easily setting up NUMA/CPU constraints.
+ */
+class NumaNodes {
+ private:
+  /**
+   * A libnuma nodestring describing which NUMA nodes this instance covers.
+   * See: man numa(3)
+   */
+  std::string nodestring_;
+  friend std::ostream& operator<<(std::ostream&, const NumaNodes&);
+
+  /**
+   * The bitmask that corresponds to the NUMA nodestring.
+   */
+  struct bitmask* numa_nodemask_;
+  struct bitmask* numa_nodemask();
+
+ public:
+  NumaNodes(const std::string& nodestring);
+  ~NumaNodes();
+
+  NumaNodes(const NumaNodes& other);
+  NumaNodes& operator=(NumaNodes other);
+  void swap(NumaNodes& other);
+
+  /**
+   * Returns the nodestring used by libnuma that represents the NUMA nodes this
+   * instance covers.
+   */
+  std::string nodestring() const;
+
+  /**
+   * Binds memory allocation and CPU affinity of the calling task to the NUMA
+   * nodes of this instance.
+   */
+  void bind();
+  /**
+   * Unbinds any previously bound memory allocation and CPU affinity of the
+   * calling task.
+   */
+  void unbind();
+
+  /**
+   * Returns how many NUMA nodes are configured on the system.
+   */
+  static size_t num_configured();
+  /**
+   * Returns the i-th partition when all NUMA nodes are grouped into a given
+   * number of partitions.
+   */
+  static NumaNodes partition(size_t ith_part, size_t num_parts);
+  /**
+   * Returns a vector of instances that cover all NUMA nodes given a number of
+   * partitions.
+   */
+  static std::vector<NumaNodes> partition(size_t num_parts);
+};
+
+std::ostream& operator<<(std::ostream&, const NumaNodes&);
+
+}  // namespace dd
+
+#endif  // DIMMWITTED_NUMA_NODES_H_


### PR DESCRIPTION
by introducing proper abstraction (`class NumaNodes`) around NUMA-aware allocation and CPU affinity setup.  Before this fix, all `-c` option values other than the number of all NUMA nodes resulted in a
suboptimal configuration: asking the kernel to use only a fraction of the memory and CPU cores for allocation and computation, e.g., with `-c 1` only NUMA node 0 and its cores were asked to be used.  The nonsensical behavior is now fixed to partition the nodes based on the number of data copies, e.g., `-c 1` on a four NUMA node machine creates and uses a bitmask for all nodes rather than just using node 0.

Fixes #37