### PR TITLE
Bug fixes for NUMA flag check and cleans CLI

### DIFF
--- a/src/cmd_parser.cc
+++ b/src/cmd_parser.cc
@@ -34,7 +34,10 @@ std::ostream& CmdParser::check(bool condition) {
   }
 }
 
-CmdParser::CmdParser(int argc, const char* const argv[]) : num_errors_(0) {
+CmdParser::CmdParser(
+    int argc, const char* const argv[],
+    const std::map<std::string, int (*)(const CmdParser&)>& modes)
+    : num_errors_(0) {
   const char* arg0 = argv[0];
   app_name = argc > 1 ? argv[1] : "";
   ++argv;
@@ -44,7 +47,7 @@ CmdParser::CmdParser(int argc, const char* const argv[]) : num_errors_(0) {
   // http://tclap.sourceforge.net/manual.html#FUNDAMENTAL_CLASSES
 
   if (app_name == "gibbs") {
-    TCLAP::CmdLine cmd_("DimmWitted GIBBS", ' ', DimmWittedVersion);
+    TCLAP::CmdLine cmd_("DimmWitted gibbs", ' ', DimmWittedVersion);
 
     TCLAP::ValueArg<std::string> fg_file_("m", "fg_meta",
                                           "factor graph metadata file", false,
@@ -225,9 +228,15 @@ CmdParser::CmdParser(int argc, const char* const argv[]) : num_errors_(0) {
     output_folder = output_folder_.getValue();
     domain_file = domain_file_.getValue();
 
-  } else {
+  } else if (argc == 0 || modes.find(app_name) == modes.cend()) {
+    ++num_errors_;
+    std::cout << "DimmWitted (https://github.com/HazyResearch/sampler)"
+              << std::endl;
+    std::cout << "Usage: " << arg0 << " MODE [ARG...]" << std::endl;
+    for (const auto mode : modes) {
+      std::cout << "  " << arg0 << " " << mode.first << std::endl;
+    }
     if (argc > 0) std::cerr << app_name << ": Unrecognized MODE" << std::endl;
-    std::cerr << "Usage: " << arg0 << " [ gibbs | bin2text ]" << std::endl;
   }
 }
 

--- a/src/cmd_parser.cc
+++ b/src/cmd_parser.cc
@@ -34,6 +34,10 @@ std::ostream& CmdParser::check(bool condition) {
   }
 }
 
+std::ostream& CmdParser::recommend(bool condition) {
+  return condition ? nullstream : std::cerr;
+}
+
 CmdParser::CmdParser(
     int argc, const char* const argv[],
     const std::map<std::string, int (*)(const CmdParser&)>& modes)
@@ -136,9 +140,9 @@ CmdParser::CmdParser(
         << "n_threads (" << n_threads
         << ") must be greater than or equal to n_datacopy (" << n_datacopy
         << "), so each copy can have at least one thread" << std::endl;
-    check(n_threads % n_datacopy == 0) << "n_threads (" << n_threads
-                                       << ") must be multiples of n_datacopy ("
-                                       << n_datacopy << ")" << std::endl;
+    recommend(n_threads % n_datacopy == 0)
+        << "n_threads (" << n_threads << ") should be multiples of n_datacopy ("
+        << n_datacopy << ") or some CPU cores will stay idle" << std::endl;
 
     burn_in = getLastValueOrDefault(burn_in_, (num_epochs_t)0);
     stepsize = getLastValueOrDefault(stepsize_, 0.01);

--- a/src/cmd_parser.cc
+++ b/src/cmd_parser.cc
@@ -124,7 +124,7 @@ CmdParser::CmdParser(
     check(0 < n_datacopy && n_datacopy <= NumaNodes::num_configured())
         << "n_datacopy (" << n_datacopy << ") must be in the range of [0, "
         << NumaNodes::num_configured() << "]" << std::endl;
-    check(n_datacopy % NumaNodes::num_configured() == 0)
+    check(NumaNodes::num_configured() % n_datacopy == 0)
         << "n_datacopy (" << n_datacopy
         << ") must be a divisor of the number of NUMA nodes ("
         << NumaNodes::num_configured() << ")" << std::endl;

--- a/src/cmd_parser.cc
+++ b/src/cmd_parser.cc
@@ -63,9 +63,6 @@ CmdParser::CmdParser(int argc, const char* const argv[]) : num_errors_(0) {
     TCLAP::MultiArg<num_epochs_t> n_learning_epoch_("l", "n_learning_epoch",
                                                     "Number of Learning Epochs",
                                                     true, "int", cmd_);
-    TCLAP::MultiArg<num_samples_t> n_samples_per_learning_epoch_(
-        "s", "n_samples_per_learning_epoch",
-        "Number of Samples per Leraning Epoch", true, "int", cmd_);
     TCLAP::MultiArg<num_epochs_t> n_inference_epoch_(
         "i", "n_inference_epoch", "Number of Samples for Inference", true,
         "int", cmd_);

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -21,6 +21,10 @@ class CmdParser {
    * A handy way to check conditions, record errors, and produce error messages.
    */
   std::ostream &check(bool condition);
+  /**
+   * A handy way to generate warning messages but don't count them as errors.
+   */
+  std::ostream &recommend(bool condition);
 
  public:
   // all the arguments are defined in cmd_parser.cpp

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 #include <ostream>
 
 namespace dd {
@@ -60,7 +61,9 @@ class CmdParser {
   /**
    * Constructs by parsing the given command line arguments
    */
-  CmdParser(int argc, const char *const argv[]);
+  CmdParser(
+      int argc, const char *const argv[],
+      const std::map<std::string, int (*)(const CmdParser &)> &modes = {});
 };
 
 std::ostream &operator<<(std::ostream &stream, const CmdParser &cmd_parser);

--- a/src/dimmwitted.cc
+++ b/src/dimmwitted.cc
@@ -25,7 +25,7 @@ int dw(int argc, const char *const argv[]) {
   };
 
   // parse command-line arguments
-  CmdParser cmd_parser(argc, argv);
+  CmdParser cmd_parser(argc, argv, MODES);
   if (cmd_parser.num_errors() > 0) return cmd_parser.num_errors();
 
   // dispatch to the correct function

--- a/test/biased_coin/dw-args
+++ b/test/biased_coin/dw-args
@@ -1,1 +1,1 @@
--l 2000 -i 2000 -s 1 --alpha 0.1 --diminish 0.995 --sample_evidence --reg_param 0
+-l 2000 -i 2000 --alpha 0.1 --diminish 0.995 --sample_evidence --reg_param 0

--- a/test/biased_coin_with_multinomial/dw-args
+++ b/test/biased_coin_with_multinomial/dw-args
@@ -1,1 +1,1 @@
--l 2000 -i 2000 -s 1 --alpha 0.1 --diminish 0.995 --sample_evidence --reg_param 0
+-l 2000 -i 2000 --alpha 0.1 --diminish 0.995 --sample_evidence --reg_param 0

--- a/test/factor_graph_test.cc
+++ b/test/factor_graph_test.cc
@@ -31,7 +31,6 @@ class FactorGraphTest : public testing::Test {
         "-o",      ".",
         "-l",      "100",
         "-i",      "100",
-        "-s",      "1",
         "--alpha", "0.1",
     };
     CmdParser cmd_parser(sizeof(argv) / sizeof(*argv), argv);

--- a/test/loading_test.cc
+++ b/test/loading_test.cc
@@ -32,7 +32,6 @@ class LoadingTest : public testing::Test {
         "-o",      ".",
         "-l",      "100",
         "-i",      "100",
-        "-s",      "1",
         "--alpha", "0.1",
     };
     CmdParser cmd_parser(sizeof(argv) / sizeof(*argv), argv);

--- a/test/partial_observation/dw-args
+++ b/test/partial_observation/dw-args
@@ -1,1 +1,1 @@
--l 500 -i 500 -s 1 --alpha 0.1 --learn_non_evidence --reg_param 0
+-l 500 -i 500 --alpha 0.1 --learn_non_evidence --reg_param 0

--- a/test/sampler_test.cc
+++ b/test/sampler_test.cc
@@ -29,7 +29,6 @@ class SamplerTest : public testing::Test {
         "-o",      ".",
         "-l",      "100",
         "-i",      "100",
-        "-s",      "1",
         "--alpha", "0.1",
     };
     CmdParser cmd_parser(sizeof(argv) / sizeof(*argv), argv);

--- a/test/sparse_domains/dw-args
+++ b/test/sparse_domains/dw-args
@@ -1,1 +1,1 @@
--l 4000 -i 2000 -s 1 --alpha 0.01 --diminish 0.999 --reg_param 0
+-l 4000 -i 2000 --alpha 0.01 --diminish 0.999 --reg_param 0

--- a/test/sparse_multinomial2/dw-args
+++ b/test/sparse_multinomial2/dw-args
@@ -1,1 +1,1 @@
--l 0 -s 1 -i 1000 --alpha 0.1 --sample_evidence
+-l 0 -i 1000 --alpha 0.1 --sample_evidence


### PR DESCRIPTION
- Fixes some incorrect and overly strict checks around NUMA/#thread flags.
- Drops ignored `-s` flag.
- Correctly displays all CLI modes.