### PR TITLE
Fix broken Gibbs chain in SGD

### DIFF
--- a/src/gibbs_sampler.h
+++ b/src/gibbs_sampler.h
@@ -131,22 +131,16 @@ inline void GibbsSamplerThread::sample_sgd_single_variable(variable_id_t vid,
   Variable &variable = fg.variables[vid];
   if (variable.is_observation) return;
 
-  if (!learn_non_evidence && !variable.is_evid) return;
+  // sample the variable
+  variable_value_t proposal = draw_sample(
+      variable, infrs.assignments_evid.get(), infrs.weight_values.get());
 
-  variable_value_t proposal = 0;
-
-  // sample the variable with evidence unchanged
-  proposal = variable.is_evid
-                 ? variable.assignment_evid
-                 : draw_sample(variable, infrs.assignments_evid.get(),
-                               infrs.weight_values.get());
-
-  infrs.assignments_evid[variable.id] = proposal;
-
-  // sample the variable regardless of whether it's evidence
-  proposal = draw_sample(variable, infrs.assignments_free.get(),
-                         infrs.weight_values.get());
   infrs.assignments_free[variable.id] = proposal;
+
+  infrs.assignments_evid[variable.id] = (
+    variable.is_evid ? variable.assignment_evid : proposal);
+
+  if (!learn_non_evidence && !variable.is_evid) return;
 
   fg.update_weight(variable, infrs, stepsize);
 }

--- a/src/gibbs_sampler.h
+++ b/src/gibbs_sampler.h
@@ -137,8 +137,8 @@ inline void GibbsSamplerThread::sample_sgd_single_variable(variable_id_t vid,
 
   infrs.assignments_free[variable.id] = proposal;
 
-  infrs.assignments_evid[variable.id] = (
-    variable.is_evid ? variable.assignment_evid : proposal);
+  infrs.assignments_evid[variable.id] =
+      (variable.is_evid ? variable.assignment_evid : proposal);
 
   if (!learn_non_evidence && !variable.is_evid) return;
 


### PR DESCRIPTION
Before this fix, the sampling steps would always skip non-evidence vars (keeping their default value).
That is fine if all factors are unary, but not okay when there are multi-var factors because
such a factor could connect a non-evid var (always at default value) and an evid var (triggers update_weights).

Will push an example in deepdive to illustrate.
