### PR TITLE
Improves libnuma API usage

### DIFF
--- a/src/numa_nodes.cc
+++ b/src/numa_nodes.cc
@@ -32,7 +32,10 @@ void numa_error(char* where) {
 namespace dd {
 
 NumaNodes::NumaNodes(const std::string& nodestring)
-    : nodestring_(nodestring), numa_nodemask_(nullptr) {}
+    : nodestring_(nodestring),
+      numa_nodemask_(nullptr),
+      numa_available_(numa_available() != -1 &&
+                      numa_num_configured_nodes() > 0) {}
 
 NumaNodes::~NumaNodes() {
   if (numa_nodemask_) numa_bitmask_free(numa_nodemask_);
@@ -49,15 +52,15 @@ void NumaNodes::swap(NumaNodes& other) {
 }
 
 struct bitmask* NumaNodes::numa_nodemask() {
-  if (!numa_nodemask_ && numa_available() != -1)
+  if (!numa_nodemask_ && numa_available_)
     numa_nodemask_ = numa_parse_nodestring(&nodestring_[0]);
   return numa_nodemask_;
 }
 void NumaNodes::bind() {
-  if (numa_available() != -1) numa_bind(numa_nodemask());
+  if (numa_available_) numa_bind(numa_nodemask());
 }
 void NumaNodes::unbind() {
-  if (numa_available() != -1) numa_bind(numa_nodemask());
+  if (numa_available_) numa_bind(numa_nodemask());
 }
 
 size_t NumaNodes::num_configured() {

--- a/src/numa_nodes.cc
+++ b/src/numa_nodes.cc
@@ -19,6 +19,14 @@
 #define numa_bitmask_alloc(n) nullptr
 #define numa_bitmask_free(bmp)
 
+void numa_warn(int number, char* where, ...) {
+  // ignore
+}
+
+void numa_error(char* where) {
+  // ignore
+}
+
 #endif  // __linux__
 
 namespace dd {

--- a/src/numa_nodes.cc
+++ b/src/numa_nodes.cc
@@ -46,7 +46,9 @@ struct bitmask* NumaNodes::numa_nodemask() {
 void NumaNodes::bind() { numa_bind(numa_nodemask()); }
 void NumaNodes::unbind() { numa_bind(numa_nodemask()); }
 
-size_t NumaNodes::num_configured() { return numa_num_configured_nodes(); }
+size_t NumaNodes::num_configured() {
+  return std::max(numa_num_configured_nodes(), 1);
+}
 
 NumaNodes NumaNodes::partition(size_t ith_part, size_t num_parts) {
   size_t num_numa_nodes = num_configured();

--- a/src/numa_nodes.h
+++ b/src/numa_nodes.h
@@ -27,6 +27,12 @@ class NumaNodes {
   struct bitmask* numa_nodemask_;
   struct bitmask* numa_nodemask();
 
+  /**
+   * Whether libnuma API is available is checked first and this flag is set.
+   * Other members will try to behave reasonably if this flag is false.
+   */
+  bool numa_available_;
+
  public:
   NumaNodes(const std::string& nodestring);
   ~NumaNodes();

--- a/test/binary_format_test.cc
+++ b/test/binary_format_test.cc
@@ -22,15 +22,15 @@ namespace dd {
 TEST(BinaryFormatTest, read_variables) {
   FactorGraph fg({18, 1, 1, 1});
   fg.load_variables("./test/biased_coin/graph.variables");
-  EXPECT_EQ(fg.size.num_variables, 18);
-  EXPECT_EQ(fg.size.num_variables_evidence, 9);
-  EXPECT_EQ(fg.size.num_variables_query, 9);
-  EXPECT_EQ(fg.variables[1].id, 1);
+  EXPECT_EQ(fg.size.num_variables, 18U);
+  EXPECT_EQ(fg.size.num_variables_evidence, 9U);
+  EXPECT_EQ(fg.size.num_variables_query, 9U);
+  EXPECT_EQ(fg.variables[1].id, 1U);
   EXPECT_EQ(fg.variables[1].domain_type, DTYPE_BOOLEAN);
   EXPECT_EQ(fg.variables[1].is_evid, true);
-  EXPECT_EQ(fg.variables[1].cardinality, 2);
-  EXPECT_EQ(fg.variables[1].assignment_evid, 1);
-  EXPECT_EQ(fg.variables[1].assignment_free, 1);
+  EXPECT_EQ(fg.variables[1].cardinality, 2U);
+  EXPECT_EQ(fg.variables[1].assignment_evid, 1U);
+  EXPECT_EQ(fg.variables[1].assignment_free, 1U);
 }
 
 // test read_factors
@@ -38,21 +38,21 @@ TEST(BinaryFormatTest, read_factors) {
   FactorGraph fg({18, 18, 1, 18});
   fg.load_variables("./test/biased_coin/graph.variables");
   fg.load_factors("./test/biased_coin/graph.factors");
-  EXPECT_EQ(fg.size.num_factors, 18);
-  EXPECT_EQ(fg.factors[0].id, 0);
-  EXPECT_EQ(fg.factors[0].weight_id, 0);
+  EXPECT_EQ(fg.size.num_factors, 18U);
+  EXPECT_EQ(fg.factors[0].id, 0U);
+  EXPECT_EQ(fg.factors[0].weight_id, 0U);
   EXPECT_EQ(fg.factors[0].func_id, FUNC_ISTRUE);
-  EXPECT_EQ(fg.factors[0].n_variables, 1);
-  EXPECT_EQ(fg.factors[1].tmp_variables.at(0).vid, 1);
-  EXPECT_EQ(fg.factors[1].tmp_variables.at(0).n_position, 0);
+  EXPECT_EQ(fg.factors[0].n_variables, 1U);
+  EXPECT_EQ(fg.factors[1].tmp_variables.at(0).vid, 1U);
+  EXPECT_EQ(fg.factors[1].tmp_variables.at(0).n_position, 0U);
 }
 
 // test read_weights
 TEST(BinaryFormatTest, read_weights) {
   FactorGraph fg({1, 1, 1, 1});
   fg.load_weights("./test/biased_coin/graph.weights");
-  EXPECT_EQ(fg.size.num_weights, 1);
-  EXPECT_EQ(fg.weights[0].id, 0);
+  EXPECT_EQ(fg.size.num_weights, 1U);
+  EXPECT_EQ(fg.weights[0].id, 0U);
   EXPECT_EQ(fg.weights[0].isfixed, false);
   EXPECT_EQ(fg.weights[0].weight, 0.0);
 }
@@ -60,7 +60,7 @@ TEST(BinaryFormatTest, read_weights) {
 // test read domains
 TEST(BinaryFormatTest, read_domains) {
   num_variables_t num_variables = 3;
-  int domain_sizes[] = {1, 2, 3};
+  variable_value_index_t domain_sizes[] = {1, 2, 3};
   FactorGraph fg({num_variables, 1, 1, 1});
 
   // add variables
@@ -74,9 +74,9 @@ TEST(BinaryFormatTest, read_domains) {
     EXPECT_EQ(fg.variables[i].domain_map->size(), domain_sizes[i]);
   }
 
-  EXPECT_EQ(fg.variables[2].get_domain_index(1), 0);
-  EXPECT_EQ(fg.variables[2].get_domain_index(3), 1);
-  EXPECT_EQ(fg.variables[2].get_domain_index(5), 2);
+  EXPECT_EQ(fg.variables[2].get_domain_index(1), 0U);
+  EXPECT_EQ(fg.variables[2].get_domain_index(3), 1U);
+  EXPECT_EQ(fg.variables[2].get_domain_index(5), 2U);
 }
 
 }  // namespace dd

--- a/test/loading_test.cc
+++ b/test/loading_test.cc
@@ -45,11 +45,11 @@ class LoadingTest : public testing::Test {
 
 // test for loading a factor graph
 TEST_F(LoadingTest, load_factor_graph) {
-  EXPECT_EQ(fg.size.num_variables, 18);
-  EXPECT_EQ(fg.size.num_variables_evidence, 9);
-  EXPECT_EQ(fg.size.num_variables_query, 9);
-  EXPECT_EQ(fg.size.num_factors, 18);
-  EXPECT_EQ(fg.size.num_weights, 1);
+  EXPECT_EQ(fg.size.num_variables, 18U);
+  EXPECT_EQ(fg.size.num_variables_evidence, 9U);
+  EXPECT_EQ(fg.size.num_variables_query, 9U);
+  EXPECT_EQ(fg.size.num_factors, 18U);
+  EXPECT_EQ(fg.size.num_weights, 1U);
 
   /* Due to how loading works in this new model, the factor graph is not
    * supposed to count the edges during loading. This only happens after

--- a/test/sampler_test.cc
+++ b/test/sampler_test.cc
@@ -68,17 +68,17 @@ TEST_F(SamplerTest, sample_single_variable) {
   infrs->weight_values[0] = 2;
 
   sampler->sample_single_variable(0);
-  EXPECT_EQ(infrs->assignments_evid[0], 1);
+  EXPECT_EQ(infrs->assignments_evid[0], 1U);
 
-  sampler->sample_single_variable(10);
-  EXPECT_EQ(infrs->assignments_evid[10], 1);
+  sampler->sample_single_variable(10U);
+  EXPECT_EQ(infrs->assignments_evid[10], 1U);
 
   infrs->weight_values[0] = 20;
-  sampler->sample_single_variable(11);
-  EXPECT_EQ(infrs->assignments_evid[11], 1);
+  sampler->sample_single_variable(11U);
+  EXPECT_EQ(infrs->assignments_evid[11], 1U);
 
-  sampler->sample_single_variable(12);
-  EXPECT_EQ(infrs->assignments_evid[12], 1);
+  sampler->sample_single_variable(12U);
+  EXPECT_EQ(infrs->assignments_evid[12], 1U);
 }
 
 }  // namespace dd


### PR DESCRIPTION
mainly to have it run nicely within containers,
by calling `numa_available()` before anything as per libnuma manual, and
handling environments with incomplete numa support (e.g., inside Docker for Mac beta containers).