### PR TITLE
Remove unnecessary Variable copy in lambda captures

### DIFF
--- a/src/inference_result.cc
+++ b/src/inference_result.cc
@@ -153,7 +153,7 @@ void InferenceResult::show_marginal_snippet(std::ostream &output) const {
           break;
 
         case DTYPE_CATEGORICAL: {
-          const auto &print_snippet = [this, &output, variable](
+          const auto &print_snippet = [this, &output, &variable](
               variable_value_t domain_value,
               variable_value_index_t domain_index) {
             output << "        @ " << domain_value << " -> EXP="
@@ -229,7 +229,7 @@ void InferenceResult::dump_marginals_in_text(std::ostream &text_output) const {
       }
 
       case DTYPE_CATEGORICAL: {
-        const auto &print_result = [this, &text_output, variable](
+        const auto &print_result = [this, &text_output, &variable](
             variable_value_t domain_value,
             variable_value_index_t domain_index) {
           text_output


### PR DESCRIPTION
I found these while tracking an apparent heisenbug where `variable.domain_map` would be null somehow. If the =operator of Variable simply "copies" the unique pointer `variable.domain_map`, this "passing by value in capture list" issue would have explained when `variable.domain_map` would be null (assigning a unique pointer effectively *moves* the payload, rendering the source into null).

However, the Variable =operator actually does a deep copy of domain_map. So the change here cannot explain the heisenbug.... Maybe somewhere else the "domain_map" unique pointer sometimes can be "stolen"...