### PR TITLE
Effective SGD regularization -- at each var instead of each epoch

### DIFF
--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -46,7 +46,7 @@ class CmdParser {
   double stepsize2;
   double decay;
   double reg_param;
-  enum regularization regularization;
+  regularization_t regularization;
 
   bool should_be_quiet;
   bool should_sample_evidence;

--- a/src/common.h
+++ b/src/common.h
@@ -83,7 +83,7 @@ typedef double feature_value_t;
  */
 #define UNUSED(var) (void)(var)
 
-enum regularization { REG_L1, REG_L2 };
+enum regularization_t { REG_L1, REG_L2 };
 
 inline bool fast_exact_is_equal(double a, double b) {
   return (a <= b && b <= a);

--- a/src/dimmwitted.cc
+++ b/src/dimmwitted.cc
@@ -190,7 +190,9 @@ void DimmWitted::learn() {
     // the average weights will be calculated and assigned to all factor graphs
     for (size_t i = 1; i < n_samplers_; ++i)
       infrs.merge_weights_from(samplers[i].infrs);
-    infrs.average_regularize_weights(current_stepsize);
+    if (n_samplers_ > 1) {
+      infrs.average_weights(n_samplers_);
+    }
     for (size_t i = 1; i < n_samplers_; ++i)
       infrs.copy_weights_to(samplers[i].infrs);
 

--- a/test/factor_graph_test.cc
+++ b/test/factor_graph_test.cc
@@ -20,6 +20,7 @@ class FactorGraphTest : public testing::Test {
  protected:
   std::unique_ptr<CompactFactorGraph> cfg;
   std::unique_ptr<InferenceResult> infrs;
+  std::unique_ptr<CmdParser> cmd_parser;
 
   virtual void SetUp() {
     const char* argv[] = {
@@ -34,17 +35,17 @@ class FactorGraphTest : public testing::Test {
         "--alpha",     "0.1",
         "--reg_param", "0",
     };
-    CmdParser cmd_parser(sizeof(argv) / sizeof(*argv), argv);
+    cmd_parser.reset(new CmdParser(sizeof(argv) / sizeof(*argv), argv));
 
     FactorGraph fg({18, 18, 1, 18});
-    fg.load_variables(cmd_parser.variable_file);
-    fg.load_weights(cmd_parser.weight_file);
-    fg.load_domains(cmd_parser.domain_file);
-    fg.load_factors(cmd_parser.factor_file);
+    fg.load_variables(cmd_parser->variable_file);
+    fg.load_weights(cmd_parser->weight_file);
+    fg.load_domains(cmd_parser->domain_file);
+    fg.load_factors(cmd_parser->factor_file);
     fg.safety_check();
 
     cfg.reset(new CompactFactorGraph(fg));
-    infrs.reset(new InferenceResult(*cfg, fg.weights.get(), cmd_parser));
+    infrs.reset(new InferenceResult(*cfg, fg.weights.get(), *cmd_parser));
   }
 };
 

--- a/test/factor_graph_test.cc
+++ b/test/factor_graph_test.cc
@@ -23,15 +23,16 @@ class FactorGraphTest : public testing::Test {
 
   virtual void SetUp() {
     const char* argv[] = {
-        "dw",      "gibbs",
-        "-w",      "./test/biased_coin/graph.weights",
-        "-v",      "./test/biased_coin/graph.variables",
-        "-f",      "./test/biased_coin/graph.factors",
-        "-m",      "./test/biased_coin/graph.meta",
-        "-o",      ".",
-        "-l",      "100",
-        "-i",      "100",
-        "--alpha", "0.1",
+        "dw",          "gibbs",
+        "-w",          "./test/biased_coin/graph.weights",
+        "-v",          "./test/biased_coin/graph.variables",
+        "-f",          "./test/biased_coin/graph.factors",
+        "-m",          "./test/biased_coin/graph.meta",
+        "-o",          ".",
+        "-l",          "100",
+        "-i",          "100",
+        "--alpha",     "0.1",
+        "--reg_param", "0",
     };
     CmdParser cmd_parser(sizeof(argv) / sizeof(*argv), argv);
 

--- a/test/sampler_test.cc
+++ b/test/sampler_test.cc
@@ -21,15 +21,16 @@ class SamplerTest : public testing::Test {
 
   virtual void SetUp() {
     const char *argv[] = {
-        "dw",      "gibbs",
-        "-w",      "./test/biased_coin/graph.weights",
-        "-v",      "./test/biased_coin/graph.variables",
-        "-f",      "./test/biased_coin/graph.factors",
-        "-m",      "./test/biased_coin/graph.meta",
-        "-o",      ".",
-        "-l",      "100",
-        "-i",      "100",
-        "--alpha", "0.1",
+        "dw",          "gibbs",
+        "-w",          "./test/biased_coin/graph.weights",
+        "-v",          "./test/biased_coin/graph.variables",
+        "-f",          "./test/biased_coin/graph.factors",
+        "-m",          "./test/biased_coin/graph.meta",
+        "-o",          ".",
+        "-l",          "100",
+        "-i",          "100",
+        "--alpha",     "0.1",
+        "--reg_param", "0",
     };
     CmdParser cmd_parser(sizeof(argv) / sizeof(*argv), argv);
     FactorGraph fg({18, 18, 1, 18});

--- a/test/sampler_test.cc
+++ b/test/sampler_test.cc
@@ -18,6 +18,7 @@ class SamplerTest : public testing::Test {
   std::unique_ptr<CompactFactorGraph> cfg;
   std::unique_ptr<InferenceResult> infrs;
   std::unique_ptr<GibbsSamplerThread> sampler;
+  std::unique_ptr<CmdParser> cmd_parser;
 
   virtual void SetUp() {
     const char *argv[] = {
@@ -32,17 +33,18 @@ class SamplerTest : public testing::Test {
         "--alpha",     "0.1",
         "--reg_param", "0",
     };
-    CmdParser cmd_parser(sizeof(argv) / sizeof(*argv), argv);
+    cmd_parser.reset(new CmdParser(sizeof(argv) / sizeof(*argv), argv));
+
     FactorGraph fg({18, 18, 1, 18});
-    fg.load_variables(cmd_parser.variable_file);
-    fg.load_weights(cmd_parser.weight_file);
-    fg.load_domains(cmd_parser.domain_file);
-    fg.load_factors(cmd_parser.factor_file);
+    fg.load_variables(cmd_parser->variable_file);
+    fg.load_weights(cmd_parser->weight_file);
+    fg.load_domains(cmd_parser->domain_file);
+    fg.load_factors(cmd_parser->factor_file);
     fg.safety_check();
 
     cfg.reset(new CompactFactorGraph(fg));
-    infrs.reset(new InferenceResult(*cfg, fg.weights.get(), cmd_parser));
-    sampler.reset(new GibbsSamplerThread(*cfg, *infrs, 0, 1, cmd_parser));
+    infrs.reset(new InferenceResult(*cfg, fg.weights.get(), *cmd_parser));
+    sampler.reset(new GibbsSamplerThread(*cfg, *infrs, 0, 1, *cmd_parser));
   }
 };
 


### PR DESCRIPTION
Before this change, the default regularization setting (l2 with reg_param = `0.01`) didn't seem effective: in simple linear chain models, we would learn astronomical weights like `51.9931` and `-456.854`. Which is actually understandable because the SGD steps ignored the regularizer and we only "regularized" the weights once per epoch with this formula:
`weight_values[j] *= (1.0 / (1.0 + opts.reg_param * current_stepsize));`

There, by default, `opts.reg_param = 0.01, current_stepsize = 0.01 * 0.95^t` so the factor is always greater than `1 / 1.00001 = 0.99999`.

With this change, we interpret `reg_param` the same way as `lambda` in formula 11 in page 9 of http://cilvr.cs.nyu.edu/diglib/lsml/bottou-sgd-tricks-2012.pdf

Namely it's a per-data-point parameter (due to the use of average instead of sum).

More importantly, now we apply the regularizer whenever we update a weight.

@chrismre @netj @zhangce let me know if I'm being naive...