### PR TITLE
Parallel load of input data files

### DIFF
--- a/src/binary_format.cc
+++ b/src/binary_format.cc
@@ -13,6 +13,9 @@
 #include <fstream>
 #include <iostream>
 #include <algorithm>
+#include <thread>
+#include <mutex>
+#include <atomic>
 
 namespace dd {
 
@@ -32,144 +35,165 @@ FactorGraphDescriptor read_meta(const std::string &meta_file) {
   return meta;
 }
 
-void FactorGraph::load_weights(const std::string &filename) {
-  std::ifstream file(filename, std::ios::binary);
-  size_t count = 0;
-  while (file && file.peek() != EOF) {
-    // read fields
-    size_t wid;
-    uint8_t isfixed;
-    double initial_value;
-    read_be_or_die(file, wid);
-    read_be_or_die(file, isfixed);
-    read_be_or_die(file, initial_value);
-    // load into factor graph
-    weights[wid] = Weight(wid, initial_value, isfixed);
-    ++count;
-  }
-  size.num_weights += count;
+#define PARALLEL_LOAD(...)                                              \
+  std::atomic<size_t> counter, counter2;                                \
+  counter = counter2 = 0;                                               \
+  std::mutex lock;                                                      \
+  std::vector<std::thread> threads;                                     \
+  for (auto &filename : filenames) {                                    \
+    threads.push_back(std::thread(                                      \
+        [&counter, &counter2, &lock, this, filename] { __VA_ARGS__ })); \
+  }                                                                     \
+  for (auto &t : threads) t.join();                                     \
+  threads.clear();
+
+void FactorGraph::load_weights(const std::vector<std::string> &filenames) {
+  PARALLEL_LOAD(std::ifstream file(filename, std::ios::binary);
+                size_t count = 0; while (file && file.peek() != EOF) {
+                  // read fields
+                  size_t wid;
+                  uint8_t isfixed;
+                  double initial_value;
+                  read_be_or_die(file, wid);
+                  read_be_or_die(file, isfixed);
+                  read_be_or_die(file, initial_value);
+                  // load into factor graph
+                  weights[wid] = Weight(wid, initial_value, isfixed);
+                  ++count;
+                } lock.lock();
+                size.num_weights += count; lock.unlock();)
 }
 
-void FactorGraph::load_variables(const std::string &filename) {
-  std::ifstream file(filename, std::ios::binary);
-  size_t count = 0;
-  while (file && file.peek() != EOF) {
-    size_t vid;
-    uint8_t role_serialized;
-    size_t initial_value;
-    uint16_t dtype_serialized;
-    size_t cardinality;
-    // read fields
-    read_be_or_die(file, vid);
-    read_be_or_die(file, role_serialized);
-    read_be_or_die(file, initial_value);
-    read_be_or_die(file, dtype_serialized);
-    read_be_or_die(file, cardinality);
-    // map serialized to internal values
-    ++count;
-    DOMAIN_TYPE dtype;
-    switch (dtype_serialized) {
-      case 0:
-        dtype = DTYPE_BOOLEAN;
-        break;
-      case 1:
-        dtype = DTYPE_CATEGORICAL;
-        break;
-      default:
-        std::cerr
-            << "[ERROR] Only Boolean and Categorical variables are supported "
-               "now!"
-            << std::endl;
-        std::abort();
-    }
-    bool is_evidence = role_serialized >= 1;
+void FactorGraph::load_variables(const std::vector<std::string> &filenames) {
+  PARALLEL_LOAD(std::ifstream file(filename, std::ios::binary);
+                size_t num_variables = 0; size_t num_variables_evidence = 0;
+                size_t num_variables_query = 0;
+                while (file && file.peek() != EOF) {
+                  size_t vid;
+                  uint8_t role_serialized;
+                  size_t initial_value;
+                  uint16_t dtype_serialized;
+                  size_t cardinality;
+                  // read fields
+                  read_be_or_die(file, vid);
+                  read_be_or_die(file, role_serialized);
+                  read_be_or_die(file, initial_value);
+                  read_be_or_die(file, dtype_serialized);
+                  read_be_or_die(file, cardinality);
+                  // map serialized to internal values
+                  DOMAIN_TYPE dtype;
+                  switch (dtype_serialized) {
+                    case 0:
+                      dtype = DTYPE_BOOLEAN;
+                      break;
+                    case 1:
+                      dtype = DTYPE_CATEGORICAL;
+                      break;
+                    default:
+                      std::cerr << "[ERROR] Only Boolean and Categorical "
+                                   "variables are supported "
+                                   "now!"
+                                << std::endl;
+                      std::abort();
+                  }
+                  bool is_evidence = role_serialized >= 1;
 
-    size_t init_value = is_evidence ? initial_value : 0;
-    variables[vid] = Variable(vid, dtype, is_evidence, cardinality, init_value);
-    ++size.num_variables;
-    if (is_evidence) {
-      ++size.num_variables_evidence;
-    } else {
-      ++size.num_variables_query;
-    }
-  }
+                  size_t init_value = is_evidence ? initial_value : 0;
+                  variables[vid] = Variable(vid, dtype, is_evidence,
+                                            cardinality, init_value);
+                  ++num_variables;
+                  if (is_evidence) {
+                    ++num_variables_evidence;
+                  } else {
+                    ++num_variables_query;
+                  }
+                } lock.lock();
+                size.num_variables += num_variables;
+                size.num_variables_evidence += num_variables_evidence;
+                size.num_variables_query += num_variables_query; lock.unlock();)
 }
 
-void FactorGraph::load_factors(const std::string &filename) {
-  std::ifstream file(filename, std::ios::binary);
-  while (file && file.peek() != EOF) {
-    uint16_t type;
-    size_t arity;
-    // read fields
-    read_be_or_die(file, type);
-    read_be_or_die(file, arity);
-    // register the factor
-    factors[size.num_factors] =
-        Factor(size.num_factors, DEFAULT_FEATURE_VALUE, Weight::INVALID_ID,
-               (FACTOR_FUNCTION_TYPE)type, arity);
-    factors[size.num_factors].vif_base = size.num_edges;
-    for (size_t position = 0; position < arity; ++position) {
-      // read fields for each variable reference
-      size_t variable_id;
-      size_t should_equal_to;
-      read_be_or_die(file, variable_id);
-      read_be_or_die(file, should_equal_to);
-      assert(variable_id < capacity.num_variables && variable_id >= 0);
-      // convert original var value into dense value
-      size_t dense_val =
-          variables[variable_id].get_domain_index(should_equal_to);
-      vifs[size.num_edges] = FactorToVariable(variable_id, dense_val);
-      // add to adjacency lists
-      if (variables[variable_id].is_boolean()) {
-        // normalize boolean var vals to 0 for indexing purpusoes
-        dense_val = Variable::BOOLEAN_DENSE_VALUE;
-      }
-      variables[variable_id].add_value_factor(dense_val, size.num_factors);
-      ++size.num_edges;
-    }
+void FactorGraph::load_factors(const std::vector<std::string> &filenames) {
+  PARALLEL_LOAD(
+      std::ifstream file(filename, std::ios::binary); size_t num_factors = 0;
+      size_t num_edges = 0; while (file && file.peek() != EOF) {
+        uint16_t type;
+        size_t arity;
+        // read fields
+        read_be_or_die(file, type);
+        read_be_or_die(file, arity);
+        // register the factor
+        size_t idx = counter.fetch_add(1, std::memory_order_relaxed);
+        ++num_factors;
+        factors[idx] = Factor(idx, DEFAULT_FEATURE_VALUE, Weight::INVALID_ID,
+                              (FACTOR_FUNCTION_TYPE)type, arity);
 
-    size_t wid;
-    read_be_or_die(file, wid);
-    factors[size.num_factors].weight_id = wid;
-    double val;
-    read_be_or_die(file, val);
-    factors[size.num_factors].feature_value = val;
+        size_t edge_idx = counter2.fetch_add(arity, std::memory_order_relaxed);
+        num_edges += arity;
+        factors[idx].vif_base = edge_idx;
+        for (size_t position = 0; position < arity; ++position) {
+          // read fields for each variable reference
+          size_t variable_id;
+          size_t should_equal_to;
+          read_be_or_die(file, variable_id);
+          read_be_or_die(file, should_equal_to);
+          assert(variable_id < capacity.num_variables && variable_id >= 0);
+          // convert original var value into dense value
+          size_t dense_val =
+              variables[variable_id].get_domain_index(should_equal_to);
+          vifs[edge_idx] = FactorToVariable(variable_id, dense_val);
+          // add to adjacency lists
+          if (variables[variable_id].is_boolean()) {
+            // normalize boolean var vals to 0 for indexing purpusoes
+            dense_val = Variable::BOOLEAN_DENSE_VALUE;
+          }
+          variables[variable_id].add_value_factor(dense_val, idx);
+          ++edge_idx;
+        }
 
-    ++size.num_factors;
-  }
+        size_t wid;
+        read_be_or_die(file, wid);
+        factors[idx].weight_id = wid;
+        double val;
+        read_be_or_die(file, val);
+        factors[idx].feature_value = val;
+      } lock.lock();
+      size.num_factors += num_factors; size.num_edges += num_edges;
+      lock.unlock();)
 }
 
-void FactorGraph::load_domains(const std::string &filename) {
-  std::ifstream file(filename, std::ios::binary);
+void FactorGraph::load_domains(const std::vector<std::string> &filenames) {
+  PARALLEL_LOAD(std::ifstream file(filename, std::ios::binary);
 
-  size_t value;
-  double truthiness;
-  while (file && file.peek() != EOF) {
-    // read field to find which categorical variable this block is for
-    size_t vid;
-    read_be_or_die(file, vid);
-    Variable &variable = variables[vid];
-    // read all category values for this variables
-    size_t domain_size;
-    read_be_or_die(file, domain_size);
+                size_t value; double truthiness;
+                while (file && file.peek() != EOF) {
+                  // read field to find which categorical variable this block is
+                  // for
+                  size_t vid;
+                  read_be_or_die(file, vid);
+                  Variable &variable = variables[vid];
+                  // read all category values for this variables
+                  size_t domain_size;
+                  read_be_or_die(file, domain_size);
 
-    assert(!variable.is_boolean());
-    assert(variable.cardinality == domain_size);
+                  assert(!variable.is_boolean());
+                  assert(variable.cardinality == domain_size);
 
-    variable.domain_map.reset(new std::unordered_map<size_t, TempVarValue>());
-    for (size_t i = 0; i < domain_size; ++i) {
-      read_be_or_die(file, value);
-      read_be_or_die(file, truthiness);
-      assert(truthiness >= 0 && truthiness <= 1);
-      (*variable.domain_map)[value] = {i, truthiness};
-    }
+                  variable.domain_map.reset(
+                      new std::unordered_map<size_t, TempVarValue>());
+                  for (size_t i = 0; i < domain_size; ++i) {
+                    read_be_or_die(file, value);
+                    read_be_or_die(file, truthiness);
+                    assert(truthiness >= 0 && truthiness <= 1);
+                    (*variable.domain_map)[value] = {i, truthiness};
+                  }
 
-    // convert original var value into dense value
-    if (variable.assignment_dense) {
-      variable.assignment_dense =
-          variable.get_domain_index(variable.assignment_dense);
-    }
-  }
+                  // convert original var value into dense value
+                  if (variable.assignment_dense) {
+                    variable.assignment_dense =
+                        variable.get_domain_index(variable.assignment_dense);
+                  }
+                })
 }
 
 }  // namespace dd

--- a/src/binary_format.cc
+++ b/src/binary_format.cc
@@ -35,165 +35,188 @@ FactorGraphDescriptor read_meta(const std::string &meta_file) {
   return meta;
 }
 
-#define PARALLEL_LOAD(...)                                              \
-  std::atomic<size_t> counter, counter2;                                \
-  counter = counter2 = 0;                                               \
-  std::mutex lock;                                                      \
-  std::vector<std::thread> threads;                                     \
-  for (auto &filename : filenames) {                                    \
-    threads.push_back(std::thread(                                      \
-        [&counter, &counter2, &lock, this, filename] { __VA_ARGS__ })); \
-  }                                                                     \
-  for (auto &t : threads) t.join();                                     \
+inline void parallel_load(
+    const std::vector<std::string> &filenames,
+    std::function<void(const std::string &filename)> loader) {
+  std::vector<std::thread> threads;
+  for (const auto &filename : filenames)
+    threads.push_back(std::thread(loader, filename));
+  for (auto &t : threads) t.join();
   threads.clear();
+}
 
 void FactorGraph::load_weights(const std::vector<std::string> &filenames) {
-  PARALLEL_LOAD(std::ifstream file(filename, std::ios::binary);
-                size_t count = 0; while (file && file.peek() != EOF) {
-                  // read fields
-                  size_t wid;
-                  uint8_t isfixed;
-                  double initial_value;
-                  read_be_or_die(file, wid);
-                  read_be_or_die(file, isfixed);
-                  read_be_or_die(file, initial_value);
-                  // load into factor graph
-                  weights[wid] = Weight(wid, initial_value, isfixed);
-                  ++count;
-                } lock.lock();
-                size.num_weights += count; lock.unlock();)
+  std::mutex mtx;
+  parallel_load(filenames, [this, &mtx](const std::string &filename) {
+    std::ifstream file(filename, std::ios::binary);
+    size_t count = 0;
+    while (file && file.peek() != EOF) {
+      // read fields
+      size_t wid;
+      uint8_t isfixed;
+      double initial_value;
+      read_be_or_die(file, wid);
+      read_be_or_die(file, isfixed);
+      read_be_or_die(file, initial_value);
+      // load into factor graph
+      weights[wid] = Weight(wid, initial_value, isfixed);
+      ++count;
+    }
+    {  // commit counts
+      std::lock_guard<std::mutex> lck(mtx);
+      size.num_weights += count;
+    }
+  });
 }
 
 void FactorGraph::load_variables(const std::vector<std::string> &filenames) {
-  PARALLEL_LOAD(std::ifstream file(filename, std::ios::binary);
-                size_t num_variables = 0; size_t num_variables_evidence = 0;
-                size_t num_variables_query = 0;
-                while (file && file.peek() != EOF) {
-                  size_t vid;
-                  uint8_t role_serialized;
-                  size_t initial_value;
-                  uint16_t dtype_serialized;
-                  size_t cardinality;
-                  // read fields
-                  read_be_or_die(file, vid);
-                  read_be_or_die(file, role_serialized);
-                  read_be_or_die(file, initial_value);
-                  read_be_or_die(file, dtype_serialized);
-                  read_be_or_die(file, cardinality);
-                  // map serialized to internal values
-                  DOMAIN_TYPE dtype;
-                  switch (dtype_serialized) {
-                    case 0:
-                      dtype = DTYPE_BOOLEAN;
-                      break;
-                    case 1:
-                      dtype = DTYPE_CATEGORICAL;
-                      break;
-                    default:
-                      std::cerr << "[ERROR] Only Boolean and Categorical "
-                                   "variables are supported "
-                                   "now!"
-                                << std::endl;
-                      std::abort();
-                  }
-                  bool is_evidence = role_serialized >= 1;
+  std::mutex mtx;
+  parallel_load(filenames, [this, &mtx](const std::string &filename) {
+    std::ifstream file(filename, std::ios::binary);
+    size_t num_variables = 0;
+    size_t num_variables_evidence = 0;
+    size_t num_variables_query = 0;
+    while (file && file.peek() != EOF) {
+      size_t vid;
+      uint8_t role_serialized;
+      size_t initial_value;
+      uint16_t dtype_serialized;
+      size_t cardinality;
+      // read fields
+      read_be_or_die(file, vid);
+      read_be_or_die(file, role_serialized);
+      read_be_or_die(file, initial_value);
+      read_be_or_die(file, dtype_serialized);
+      read_be_or_die(file, cardinality);
+      // map serialized to internal values
+      DOMAIN_TYPE dtype;
+      switch (dtype_serialized) {
+        case 0:
+          dtype = DTYPE_BOOLEAN;
+          break;
+        case 1:
+          dtype = DTYPE_CATEGORICAL;
+          break;
+        default:
+          std::cerr << "[ERROR] Only Boolean and Categorical "
+                       "variables are supported "
+                       "now!"
+                    << std::endl;
+          std::abort();
+      }
+      bool is_evidence = role_serialized >= 1;
 
-                  size_t init_value = is_evidence ? initial_value : 0;
-                  variables[vid] = Variable(vid, dtype, is_evidence,
-                                            cardinality, init_value);
-                  ++num_variables;
-                  if (is_evidence) {
-                    ++num_variables_evidence;
-                  } else {
-                    ++num_variables_query;
-                  }
-                } lock.lock();
-                size.num_variables += num_variables;
-                size.num_variables_evidence += num_variables_evidence;
-                size.num_variables_query += num_variables_query; lock.unlock();)
+      size_t init_value = is_evidence ? initial_value : 0;
+      variables[vid] =
+          Variable(vid, dtype, is_evidence, cardinality, init_value);
+      ++num_variables;
+      if (is_evidence) {
+        ++num_variables_evidence;
+      } else {
+        ++num_variables_query;
+      }
+    }
+    {  // commit counts
+      std::lock_guard<std::mutex> lck(mtx);
+      size.num_variables += num_variables;
+      size.num_variables_evidence += num_variables_evidence;
+      size.num_variables_query += num_variables_query;
+    }
+  });
 }
 
 void FactorGraph::load_factors(const std::vector<std::string> &filenames) {
-  PARALLEL_LOAD(
-      std::ifstream file(filename, std::ios::binary); size_t num_factors = 0;
-      size_t num_edges = 0; while (file && file.peek() != EOF) {
-        uint16_t type;
-        size_t arity;
-        // read fields
-        read_be_or_die(file, type);
-        read_be_or_die(file, arity);
-        // register the factor
-        size_t idx = counter.fetch_add(1, std::memory_order_relaxed);
-        ++num_factors;
-        factors[idx] = Factor(idx, DEFAULT_FEATURE_VALUE, Weight::INVALID_ID,
-                              (FACTOR_FUNCTION_TYPE)type, arity);
+  std::mutex mtx;
+  std::atomic<size_t> factor_cntr(0), edge_cntr(0);
+  parallel_load(filenames, [this, &mtx, &factor_cntr,
+                            &edge_cntr](const std::string &filename) {
+    std::ifstream file(filename, std::ios::binary);
+    size_t num_factors = 0;
+    size_t num_edges = 0;
+    while (file && file.peek() != EOF) {
+      uint16_t type;
+      size_t arity;
+      // read fields
+      read_be_or_die(file, type);
+      read_be_or_die(file, arity);
+      // register the factor
+      size_t idx = factor_cntr.fetch_add(1, std::memory_order_relaxed);
+      ++num_factors;
+      factors[idx] = Factor(idx, DEFAULT_FEATURE_VALUE, Weight::INVALID_ID,
+                            (FACTOR_FUNCTION_TYPE)type, arity);
 
-        size_t edge_idx = counter2.fetch_add(arity, std::memory_order_relaxed);
-        num_edges += arity;
-        factors[idx].vif_base = edge_idx;
-        for (size_t position = 0; position < arity; ++position) {
-          // read fields for each variable reference
-          size_t variable_id;
-          size_t should_equal_to;
-          read_be_or_die(file, variable_id);
-          read_be_or_die(file, should_equal_to);
-          assert(variable_id < capacity.num_variables && variable_id >= 0);
-          // convert original var value into dense value
-          size_t dense_val =
-              variables[variable_id].get_domain_index(should_equal_to);
-          vifs[edge_idx] = FactorToVariable(variable_id, dense_val);
-          // add to adjacency lists
-          if (variables[variable_id].is_boolean()) {
-            // normalize boolean var vals to 0 for indexing purpusoes
-            dense_val = Variable::BOOLEAN_DENSE_VALUE;
-          }
-          variables[variable_id].add_value_factor(dense_val, idx);
-          ++edge_idx;
+      size_t edge_idx = edge_cntr.fetch_add(arity, std::memory_order_relaxed);
+      num_edges += arity;
+      factors[idx].vif_base = edge_idx;
+      for (size_t position = 0; position < arity; ++position) {
+        // read fields for each variable reference
+        size_t variable_id;
+        size_t should_equal_to;
+        read_be_or_die(file, variable_id);
+        read_be_or_die(file, should_equal_to);
+        assert(variable_id < capacity.num_variables && variable_id >= 0);
+        // convert original var value into dense value
+        size_t dense_val =
+            variables[variable_id].get_domain_index(should_equal_to);
+        vifs[edge_idx] = FactorToVariable(variable_id, dense_val);
+        // add to adjacency lists
+        if (variables[variable_id].is_boolean()) {
+          // normalize boolean var vals to 0 for indexing purpusoes
+          dense_val = Variable::BOOLEAN_DENSE_VALUE;
         }
+        variables[variable_id].add_value_factor(dense_val, idx);
+        ++edge_idx;
+      }
 
-        size_t wid;
-        read_be_or_die(file, wid);
-        factors[idx].weight_id = wid;
-        double val;
-        read_be_or_die(file, val);
-        factors[idx].feature_value = val;
-      } lock.lock();
-      size.num_factors += num_factors; size.num_edges += num_edges;
-      lock.unlock();)
+      size_t wid;
+      read_be_or_die(file, wid);
+      factors[idx].weight_id = wid;
+      double val;
+      read_be_or_die(file, val);
+      factors[idx].feature_value = val;
+    }
+    {  // commit counts
+      std::lock_guard<std::mutex> lck(mtx);
+      size.num_factors += num_factors;
+      size.num_edges += num_edges;
+    }
+  });
 }
 
 void FactorGraph::load_domains(const std::vector<std::string> &filenames) {
-  PARALLEL_LOAD(std::ifstream file(filename, std::ios::binary);
+  parallel_load(filenames, [this](const std::string &filename) {
+    std::ifstream file(filename, std::ios::binary);
 
-                size_t value; double truthiness;
-                while (file && file.peek() != EOF) {
-                  // read field to find which categorical variable this block is
-                  // for
-                  size_t vid;
-                  read_be_or_die(file, vid);
-                  Variable &variable = variables[vid];
-                  // read all category values for this variables
-                  size_t domain_size;
-                  read_be_or_die(file, domain_size);
+    size_t value;
+    double truthiness;
+    while (file && file.peek() != EOF) {
+      // read field to find which categorical variable this block is
+      // for
+      size_t vid;
+      read_be_or_die(file, vid);
+      Variable &variable = variables[vid];
+      // read all category values for this variables
+      size_t domain_size;
+      read_be_or_die(file, domain_size);
 
-                  assert(!variable.is_boolean());
-                  assert(variable.cardinality == domain_size);
+      assert(!variable.is_boolean());
+      assert(variable.cardinality == domain_size);
 
-                  variable.domain_map.reset(
-                      new std::unordered_map<size_t, TempVarValue>());
-                  for (size_t i = 0; i < domain_size; ++i) {
-                    read_be_or_die(file, value);
-                    read_be_or_die(file, truthiness);
-                    assert(truthiness >= 0 && truthiness <= 1);
-                    (*variable.domain_map)[value] = {i, truthiness};
-                  }
+      variable.domain_map.reset(new std::unordered_map<size_t, TempVarValue>());
+      for (size_t i = 0; i < domain_size; ++i) {
+        read_be_or_die(file, value);
+        read_be_or_die(file, truthiness);
+        assert(truthiness >= 0 && truthiness <= 1);
+        (*variable.domain_map)[value] = {i, truthiness};
+      }
 
-                  // convert original var value into dense value
-                  if (variable.assignment_dense) {
-                    variable.assignment_dense =
-                        variable.get_domain_index(variable.assignment_dense);
-                  }
-                })
+      // convert original var value into dense value
+      if (variable.assignment_dense) {
+        variable.assignment_dense =
+            variable.get_domain_index(variable.assignment_dense);
+      }
+    }
+  });
 }
 
 }  // namespace dd

--- a/src/cmd_parser.cc
+++ b/src/cmd_parser.cc
@@ -1,3 +1,6 @@
+#include <iostream>
+#include <iterator>
+
 #include "cmd_parser.h"
 #include "numa_nodes.h"
 
@@ -56,16 +59,18 @@ CmdParser::CmdParser(
     TCLAP::ValueArg<std::string> fg_file_("m", "fg_meta",
                                           "factor graph metadata file", false,
                                           "", "string", cmd_);
-    TCLAP::ValueArg<std::string> variable_file_(
-        "v", "variables", "variables file", false, "", "string", cmd_);
-    TCLAP::ValueArg<std::string> factor_file_("f", "factors", "factors file",
-                                              false, "", "string", cmd_);
-    TCLAP::ValueArg<std::string> weight_file_("w", "weights", "weights file",
-                                              false, "", "string", cmd_);
+
+    TCLAP::MultiArg<std::string> variable_file_(
+        "v", "variables", "variables file", false, "string", cmd_);
+    TCLAP::MultiArg<std::string> domain_file_(
+        "", "domains", "categorical domains", false, "string", cmd_);
+    TCLAP::MultiArg<std::string> factor_file_("f", "factors", "factors file",
+                                              false, "string", cmd_);
+    TCLAP::MultiArg<std::string> weight_file_("w", "weights", "weights file",
+                                              false, "string", cmd_);
+
     TCLAP::ValueArg<std::string> output_folder_(
         "o", "outputFile", "Output Folder", false, "", "string", cmd_);
-    TCLAP::ValueArg<std::string> domain_file_(
-        "", "domains", "Categorical domains", false, "", "string", cmd_);
 
     TCLAP::MultiArg<size_t> n_learning_epoch_("l", "n_learning_epoch",
                                               "Number of Learning Epochs", true,
@@ -219,25 +224,27 @@ CmdParser::CmdParser(
     TCLAP::ValueArg<std::string> fg_file_("m", "fg_meta",
                                           "factor graph metadata file", false,
                                           "", "string", cmd_);
-    TCLAP::ValueArg<std::string> variable_file_(
-        "v", "variables", "variables file", false, "", "string", cmd_);
-    TCLAP::ValueArg<std::string> factor_file_("f", "factors", "factors file",
-                                              false, "", "string", cmd_);
-    TCLAP::ValueArg<std::string> weight_file_("w", "weights", "weights file",
-                                              false, "", "string", cmd_);
+
+    TCLAP::MultiArg<std::string> variable_file_(
+        "v", "variables", "variables file", false, "string", cmd_);
+    TCLAP::MultiArg<std::string> domain_file_(
+        "", "domains", "categorical domains", false, "string", cmd_);
+    TCLAP::MultiArg<std::string> factor_file_("f", "factors", "factors file",
+                                              false, "string", cmd_);
+    TCLAP::MultiArg<std::string> weight_file_("w", "weights", "weights file",
+                                              false, "string", cmd_);
+
     TCLAP::ValueArg<std::string> output_folder_(
         "o", "outputFile", "Output Folder", false, "", "string", cmd_);
-    TCLAP::ValueArg<std::string> domain_file_(
-        "", "domains", "Categorical domains", false, "", "string", cmd_);
 
     cmd_.parse(argc, argv);
 
     fg_file = fg_file_.getValue();
     variable_file = variable_file_.getValue();
+    domain_file = domain_file_.getValue();
     factor_file = factor_file_.getValue();
     weight_file = weight_file_.getValue();
     output_folder = output_folder_.getValue();
-    domain_file = domain_file_.getValue();
 
   } else if (argc == 0 || modes.find(app_name) == modes.cend()) {
     ++num_errors_;
@@ -251,11 +258,22 @@ CmdParser::CmdParser(
   }
 }
 
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
+  if (!v.empty()) {
+    out << '[';
+    std::copy(v.begin(), v.end(), std::ostream_iterator<T>(out, ", "));
+    out << "\b\b]";
+  }
+  return out;
+}
+
 std::ostream& operator<<(std::ostream& stream, const CmdParser& args) {
   stream << "#################GIBBS SAMPLING#################" << std::endl;
   stream << "# fg_file            : " << args.fg_file << std::endl;
-  stream << "# weight_file        : " << args.weight_file << std::endl;
   stream << "# variable_file      : " << args.variable_file << std::endl;
+  stream << "# domain_file        : " << args.domain_file << std::endl;
+  stream << "# weight_file        : " << args.weight_file << std::endl;
   stream << "# factor_file        : " << args.factor_file << std::endl;
   stream << "# output_folder      : " << args.output_folder << std::endl;
   stream << "# n_learning_epoch   : " << args.n_learning_epoch << std::endl;

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -31,11 +31,11 @@ class CmdParser {
   std::string app_name;
 
   std::string fg_file;
-  std::string variable_file;
-  std::string factor_file;
-  std::string weight_file;
+  std::vector<std::string> variable_file;
+  std::vector<std::string> domain_file;
+  std::vector<std::string> factor_file;
+  std::vector<std::string> weight_file;
   std::string output_folder;
-  std::string domain_file;
 
   size_t n_learning_epoch;
   size_t n_inference_epoch;
@@ -74,6 +74,9 @@ class CmdParser {
       int argc, const char *const argv[],
       const std::map<std::string, int (*)(const CmdParser &)> &modes = {});
 };
+
+template <typename T>
+std::ostream &operator<<(std::ostream &out, const std::vector<T> &v);
 
 std::ostream &operator<<(std::ostream &stream, const CmdParser &cmd_parser);
 

--- a/src/dimmwitted.cc
+++ b/src/dimmwitted.cc
@@ -59,9 +59,10 @@ int gibbs(const CmdParser &args) {
   NumaNodes::partition(0, args.n_datacopy).bind();
 
   // Load factor graph
-  dprintf("Initializing factor graph...\n");
+  std::cout << "\tinitializing factor graph..." << std::endl;
   FactorGraph *fg = new FactorGraph(meta);
 
+  std::cout << "\tloading factor graph..." << std::endl;
   fg->load_variables(args.variable_file);
   fg->load_weights(args.weight_file);
   fg->load_domains(args.domain_file);

--- a/src/factor_graph.h
+++ b/src/factor_graph.h
@@ -69,10 +69,10 @@ class FactorGraph {
   std::unique_ptr<size_t[]> factor_index;
   std::unique_ptr<VariableToFactor[]> values;
 
-  void load_weights(const std::string& filename);
-  void load_variables(const std::string& filename);
-  void load_factors(const std::string& filename);
-  void load_domains(const std::string& filename);
+  void load_weights(const std::vector<std::string>& filenames);
+  void load_variables(const std::vector<std::string>& filenames);
+  void load_factors(const std::vector<std::string>& filenames);
+  void load_domains(const std::vector<std::string>& filenames);
 
   // count data structures to ensure consistency with declared size
   void safety_check();

--- a/test/binary_format_test.cc
+++ b/test/binary_format_test.cc
@@ -21,7 +21,7 @@ namespace dd {
 // test read_variables
 TEST(BinaryFormatTest, read_variables) {
   FactorGraph fg({18, 1, 1, 1});
-  fg.load_variables("./test/biased_coin/graph.variables");
+  fg.load_variables({"./test/biased_coin/graph.variables"});
   EXPECT_EQ(fg.size.num_variables, 18U);
   EXPECT_EQ(fg.size.num_variables_evidence, 9U);
   EXPECT_EQ(fg.size.num_variables_query, 9U);
@@ -35,8 +35,8 @@ TEST(BinaryFormatTest, read_variables) {
 // test read_factors
 TEST(BinaryFormatTest, read_factors) {
   FactorGraph fg({18, 18, 1, 18});
-  fg.load_variables("./test/biased_coin/graph.variables");
-  fg.load_factors("./test/biased_coin/graph.factors");
+  fg.load_variables({"./test/biased_coin/graph.variables"});
+  fg.load_factors({"./test/biased_coin/graph.factors"});
   EXPECT_EQ(fg.size.num_factors, 18U);
   EXPECT_EQ(fg.factors[0].id, 0U);
   EXPECT_EQ(fg.factors[0].weight_id, 0U);
@@ -48,7 +48,7 @@ TEST(BinaryFormatTest, read_factors) {
 // test read_weights
 TEST(BinaryFormatTest, read_weights) {
   FactorGraph fg({1, 1, 1, 1});
-  fg.load_weights("./test/biased_coin/graph.weights");
+  fg.load_weights({"./test/biased_coin/graph.weights"});
   EXPECT_EQ(fg.size.num_weights, 1U);
   EXPECT_EQ(fg.weights[0].id, 0U);
   EXPECT_EQ(fg.weights[0].isfixed, false);
@@ -65,7 +65,7 @@ TEST(BinaryFormatTest, read_domains) {
   for (size_t i = 0; i < num_variables; ++i) {
     fg.variables[i] = Variable(i, DTYPE_CATEGORICAL, false, domain_sizes[i], 0);
   }
-  fg.load_domains("./test/domains/graph.domains");
+  fg.load_domains({"./test/domains/graph.domains"});
 
   for (size_t i = 0; i < num_variables; ++i) {
     EXPECT_EQ(fg.variables[i].domain_map->size(), domain_sizes[i]);


### PR DESCRIPTION
This implements @netj's idea of loading split files in parallel to address the single-threaded loading bottleneck (seems mostly with `read_be`). The changes in `binary_format.cc` are mostly format changes from `make format`... The main addition is the `PARALLEL_LOAD` macro to load each split file in a dedicated thread.

Tested on an FG with 300M factors.