### PR TITLE
Parallelize and streamline in-memory FG allocation, copying, and indexing

### DIFF
--- a/src/factor_graph.h
+++ b/src/factor_graph.h
@@ -100,6 +100,8 @@ class FactorGraph {
   // copy constructor
   FactorGraph(const FactorGraph& other);
 
+  ~FactorGraph();
+
   /**
    * Given a variable, updates the weights associated with the factors that
    * connect to the variable.

--- a/src/factor_graph.h
+++ b/src/factor_graph.h
@@ -79,6 +79,9 @@ class FactorGraph {
   // construct "values" and "factor_index" for var-to-factor lookups
   void construct_index();
 
+  void construct_index_part(size_t v_start, size_t v_end, size_t val_base,
+                            size_t fac_base);
+
   inline size_t get_var_value_at(const Variable& var, size_t idx) const {
     return values[var.var_val_base + idx].value;
   }

--- a/test/biased_coin_with_multinomial/dw-args
+++ b/test/biased_coin_with_multinomial/dw-args
@@ -1,1 +1,1 @@
--l 2000 -i 2000 --alpha 0.1 --diminish 0.995 --sample_evidence --reg_param 0
+-l 2000 -i 2000 --alpha 0.01 --diminish 0.995 --sample_evidence --reg_param 0


### PR DESCRIPTION
1. Allocating big arrays as `void *` instead of `Factor *` is 60X+ faster.
2. Parallelizing `std::copy` is 6X faster.
3. Parallelizing FG indexing (var-value, var-factor) is 5X faster.

These combined with the previous parallel-file-split-loading reduces DW initialization time on a 300M-factor graph from 10min to 1min.